### PR TITLE
Show the usage of build.sh in Debug Mode and define the macro DEBUG 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(alex)
 
 set(CMAKE_CXX_STANDARD 14)
 
-# Define the macro ‘DEBUG' to be true in the debug mode
+# Define the macro ‘DEBUG' in the debug mode
 if(CMAKE_BUILD_TYPE STREQUAL Debug)        
     ADD_DEFINITIONS(-DDEBUG)               
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,11 @@ project(alex)
 
 set(CMAKE_CXX_STANDARD 14)
 
+# Define the macro ‘DEBUG' to be true in the debug mode
+if(CMAKE_BUILD_TYPE STREQUAL Debug)        
+    ADD_DEFINITIONS(-DDEBUG)               
+endif()
+
 if(MSVC)
     set(CMAKE_CXX_FLAGS "/O2 /arch:AVX2 /W1 /EHsc")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Intel")

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ On Linux/Mac, use the following commands:
 # Build using CMake, which creates a new build directory
 ./build.sh
 
+# Build using CMake in Debug Mode, which creates a new build_debug directory and defines the macro ‘DEBUG'
+./build.sh debug
+
 # Run example program
 ./build/example
 


### PR DESCRIPTION
Hi there, I see the build.sh only tell CMake to compile in Debug Mode, and README does not show this usage. In addition to the update of README, I also define the macro DEBUG in CMakeLists.txt. I think this may be helpful for developers to debug.