### PR TITLE
Allow compilation outside Visual Studio

### DIFF
--- a/src/core/alex_base.h
+++ b/src/core/alex_base.h
@@ -186,12 +186,12 @@ inline int get_offset(int word_id, uint64_t bit) {
 /*** Cost model weights ***/
 
 // Intra-node cost weights
-double kExpSearchIterationsWeight = 20;
-double kShiftsWeight = 0.5;
+constexpr double kExpSearchIterationsWeight = 20;
+constexpr double kShiftsWeight = 0.5;
 
 // TraverseToLeaf cost weights
-double kNodeLookupsWeight = 20;
-double kModelSizeWeight = 5e-7;
+constexpr double kNodeLookupsWeight = 20;
+constexpr double kModelSizeWeight = 5e-7;
 
 /*** Stat Accumulators ***/
 
@@ -385,7 +385,7 @@ class CPUID {
 };
 
 // https://en.wikipedia.org/wiki/CPUID#EAX=7,_ECX=0:_Extended_Features
-bool cpu_supports_bmi() {
+inline bool cpu_supports_bmi() {
   return static_cast<bool>(CPUID(7, 0).EBX() & (1 << 3));
 }
 }

--- a/src/core/alex_fanout_tree.h
+++ b/src/core/alex_fanout_tree.h
@@ -35,7 +35,7 @@ struct FTNode {
 /*** Helpers ***/
 
 // Collect all used fanout tree nodes and sort them
-void collect_used_nodes(const std::vector<std::vector<FTNode>>& fanout_tree,
+inline void collect_used_nodes(const std::vector<std::vector<FTNode>>& fanout_tree,
                         int max_level,
                         std::vector<FTNode>& used_fanout_tree_nodes) {
   max_level = std::min(max_level, static_cast<int>(fanout_tree.size()) - 1);


### PR DESCRIPTION
A couple of files are missing the `inline` and `constexpr` keywords. Without these, multiple definitions exist whenever _alex.h_ is included more than once.