### PR TITLE
attempt to fix some bugs of null pointers, 0 slopes, and 1 expansion factors

### DIFF
--- a/src/core/alex_base.h
+++ b/src/core/alex_base.h
@@ -127,8 +127,14 @@ class LinearModelBuilder {
 
     // If floating point precision errors, fit spline
     if (model_->a_ <= 0) {
-      model_->a_ = (y_max_ - y_min_) / (x_max_ - x_min_);
-      model_->b_ = -static_cast<double>(x_min_) * model_->a_;
+      if (x_max_ - x_min_ == 0){
+        model_->a_ = 0;
+        model_->b_ = static_cast<double>(y_sum_) / count_;
+      }
+      else{
+        model_->a_ = (y_max_ - y_min_) / (x_max_ - x_min_);
+        model_->b_ = -static_cast<double>(x_min_) * model_->a_;
+      }
     }
   }
 

--- a/src/core/alex_fanout_tree.h
+++ b/src/core/alex_fanout_tree.h
@@ -362,13 +362,19 @@ int find_best_fanout_existing_node(const AlexModelNode<T, P>* parent,
       bucketID - (bucketID % repeats);  // first bucket with same child
   int end_bucketID =
       start_bucketID + repeats;  // first bucket with different child
-  double left_boundary_value =
-      (start_bucketID - parent->model_.b_) / parent->model_.a_;
-  double right_boundary_value =
-      (end_bucketID - parent->model_.b_) / parent->model_.a_;
   LinearModel<T> base_model;
-  base_model.a_ = 1.0 / (right_boundary_value - left_boundary_value);
-  base_model.b_ = -1.0 * base_model.a_ * left_boundary_value;
+  if (parent->model_.a_ == 0){
+    base_model.a_ = 0;
+    base_model.b_ = -1.0 * (start_bucketID - parent->model_.b_) / repeats;
+  }
+  else{
+    double left_boundary_value =
+      (start_bucketID - parent->model_.b_) / parent->model_.a_;
+    double right_boundary_value =
+        (end_bucketID - parent->model_.b_) / parent->model_.a_;
+    base_model.a_ = 1.0 / (right_boundary_value - left_boundary_value);
+    base_model.b_ = -1.0 * base_model.a_ * left_boundary_value;
+  }
 
   for (int fanout = 1, fanout_tree_level = 0; fanout <= max_fanout;
        fanout *= 2, fanout_tree_level++) {

--- a/src/core/alex_nodes.h
+++ b/src/core/alex_nodes.h
@@ -1410,7 +1410,8 @@ class AlexDataNode : public AlexNode<T, P> {
       }
       builder.build();
 
-      double rel_change_in_a = std::abs((model->a_ - prev_a) / prev_a);
+      double rel_change_in_a = prev_a == 0 ? (model->a_ != 0) 
+                               : std::abs((model->a_ - prev_a) / prev_a);
       double abs_change_in_b = std::abs(model->b_ - prev_b);
       double rel_change_in_b = std::abs(abs_change_in_b / prev_b);
       if (verbose) {
@@ -1659,14 +1660,14 @@ class AlexDataNode : public AlexNode<T, P> {
   // splitting
   inline bool significant_cost_deviation() const {
     double emp_cost = empirical_cost();
-    return emp_cost > kNodeLookupsWeight && emp_cost > 1.5 * this->cost_;
+    return this->model_.a_ != 0 && emp_cost > kNodeLookupsWeight && emp_cost > 1.5 * this->cost_;
   }
 
   // Returns true if cost is catastrophically high and we want to force a split
   // The heuristic for this is if the number of shifts per insert (expected or
   // empirical) is over 100
   inline bool catastrophic_cost() const {
-    return shifts_per_insert() > 100 || expected_avg_shifts_ > 100;
+    return this->model_.a_ != 0 && shifts_per_insert() > 100 || expected_avg_shifts_ > 100;
   }
 
   // First value in returned pair is fail flag:


### PR DESCRIPTION
1. In function "expand_root" (alex.h), all pointers must be assigned to resolve issue #26 .
2. The case that the slope is equal to 0 must be carefully check to prevent emergence of infinite.
3. In function "significant_cost_deviation" and "catastrophic_cost" (alex_nodes.h), if the slope is equal to 0, keys of the data node are equal and should not be split. Otherwise, one key cannot be mapped to different data nodes.
4.  In function "expand_root" (alex.h), the computation of expansion factor should be more precise for long long int, especially for "ceil" function, or expansion factor may be equal to 1.